### PR TITLE
Be om lesetilgang til ressurs når vi oppretter systembrukerforespørsler

### DIFF
--- a/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/AltinnService.kt
+++ b/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/AltinnService.kt
@@ -24,7 +24,7 @@ class AltinnService {
                 rights =
                     listOf(
                         Right(
-                            action = "write",
+                            action = "read",
                             resource =
                                 listOf(
                                     AttributePair(

--- a/lps-client-frontend/src/App.js
+++ b/lps-client-frontend/src/App.js
@@ -15,7 +15,7 @@ function App() {
           TigerSys
         </Typography>
         <Typography variant="subtitle1" align="center" gutterBottom>
-          Ditt lønns og personalsystem
+          Ditt lønns- og personalsystem
         </Typography>
         <Routes>
           <Route path="/" element={<LoginForm />} />


### PR DESCRIPTION
Ressursen vår `nav_sykepenger_inntektsmelding-nedlasting` ligger nå i ressursregisteret til Altinn med actionen `read` (som jo gir mer mening for et les-API.) Tidligere lå den inne med `write`.