### PR TITLE
Lag mulighet for å legge til flere scopes når man henter systembrukertoken

### DIFF
--- a/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/SystemBrukerRouting.kt
+++ b/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/plugins/SystemBrukerRouting.kt
@@ -38,13 +38,15 @@ private fun Routing.hentSystembruker(maskinportenService: MaskinportenService) {
                 HttpStatusCode.BadRequest,
                 "Missing 'orgnr' parameter",
             )
+        val scopes =
+            parameters["scopes"] ?: "nav:helse/im.read"
 
         try {
             val systemBrukerClaim =
                 maskinportenService
                     .getMaskinportenTokenForSystembruker(
                         orgnr,
-                        "nav:helse/im.read",
+                        scopes,
                     ).fetchNewAccessToken()
 
             logger().info("token: $systemBrukerClaim")


### PR DESCRIPTION
Vi trenger dette for å enkelt kunne hente tokens med f.eks. dialogporten- og altinnevents-scopes. Tenkte å ta det i bruk i Bruno-collection med en gang.