### PR TITLE
Samle json config i utils-fil for å ikke tryne på ukjente felter i respons

### DIFF
--- a/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
+++ b/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/Application.kt
@@ -8,11 +8,11 @@ import io.ktor.server.application.install
 import io.ktor.server.netty.EngineMain
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.cors.routing.CORS
-import kotlinx.serialization.json.Json
 import no.nav.helsearbeidsgiver.maskinporten.MaskinportenService
 import no.nav.helsearbeidsgiver.plugins.configureLpsApiRouting
 import no.nav.helsearbeidsgiver.plugins.configureSystembrukerRouting
 import no.nav.helsearbeidsgiver.plugins.configureTokenRouting
+import no.nav.helsearbeidsgiver.utils.jsonConfig
 
 fun main(args: Array<String>) {
     EngineMain.main(args)
@@ -21,11 +21,7 @@ fun main(args: Array<String>) {
 fun Application.module() {
     install(ContentNegotiation) {
         json(
-            Json {
-                prettyPrint = true
-                isLenient = true
-                ignoreUnknownKeys = true
-            },
+            jsonConfig,
         )
     }
 

--- a/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/maskinporten/MaskinPortenHttpClient.kt
+++ b/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/maskinporten/MaskinPortenHttpClient.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import no.nav.helsearbeidsgiver.utils.jsonConfig
 
 internal fun createHttpClient(): HttpClient = HttpClient(Apache5) { configure() }
@@ -12,6 +13,8 @@ internal fun HttpClientConfig<*>.configure() {
     expectSuccess = true
 
     install(ContentNegotiation) {
-        jsonConfig
+        json(
+            jsonConfig,
+        )
     }
 }

--- a/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/maskinporten/MaskinPortenHttpClient.kt
+++ b/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/maskinporten/MaskinPortenHttpClient.kt
@@ -4,7 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.serialization.kotlinx.json.json
+import no.nav.helsearbeidsgiver.utils.jsonConfig
 
 internal fun createHttpClient(): HttpClient = HttpClient(Apache5) { configure() }
 
@@ -12,6 +12,6 @@ internal fun HttpClientConfig<*>.configure() {
     expectSuccess = true
 
     install(ContentNegotiation) {
-        json()
+        jsonConfig
     }
 }

--- a/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SerializerUtilsKt.kt
+++ b/lps-client-backend/src/main/kotlin/no/nav/helsearbeidsgiver/utils/SerializerUtilsKt.kt
@@ -3,7 +3,15 @@ package no.nav.helsearbeidsgiver.utils
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.SetSerializer
+import kotlinx.serialization.json.Json
 
 fun <T> KSerializer<T>.list(): KSerializer<List<T>> = ListSerializer(this)
 
 fun <T> KSerializer<T>.set(): KSerializer<Set<T>> = SetSerializer(this)
+
+val jsonConfig =
+    Json {
+        prettyPrint = true
+        isLenient = true
+        ignoreUnknownKeys = true
+    }


### PR DESCRIPTION
**Bakgrunn**
Vi klarer ikke opprette nye systembrukerforespørsler fordi Altinn har lagt inn et nytt felt i responsen sin og vi tryner på ukjente verdier når vi mapper responsen til json.

**Løsning**
Samle json-config med `ignoreUnknownKeys = true` i SerializerUtilsKt.kt.